### PR TITLE
change title of extension configuration

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
 	"contributes": {
 		"configuration": {
 			"type": "object",
-			"title": "Max Number of Problems",
+			"title": "CSSLint Extension",
 			"properties": {
 				"cssLanguageClient.maxNumberOfProblems": {
 					"type": "number",


### PR DESCRIPTION
changed the title of the configuration so that all settings for this extension are grouped under the name "CSSLint Extension" in VS Code settings